### PR TITLE
Bugfix/query params override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ api.sock
 sql/db/
 variables.env*
 *.swp
+
+# Jetbrains files
+.idea/*

--- a/www/history.js
+++ b/www/history.js
@@ -15,15 +15,16 @@ function main() {
     });
     reset_date();
     const params = new URLSearchParams(window.location.search);
+    const size = Array.from(params).length;
     // stupid logic, don't care
-    if (params.size === 1) {
+    if (size === 1) {
         document.getElementById("search-group-name").value = params.get("group_name").toUpperCase();
         search_ping_log();
-    } else if (params.size === 2) {
+    } else if (size === 2) {
         document.getElementById("search-count").value = params.get("count");
         document.getElementById("search-group-name").value = params.get("group_name").toUpperCase();
         search_ping_log();
-    } else if (params.size > 1) {
+    } else if (size > 1) {
         document.getElementById("search-group-name").value = params.get("group_name").toUpperCase();
         document.getElementById("search-count").value = params.get("count");
         const epoch = new Date(params.get("epoch_sec") * 1000);


### PR DESCRIPTION
Use array length to account for compatibility issues with current Safari (v16). 

`(new UrlSearchParams('?foo=bar')).size` is under [experimental implementation](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/size) in a future major version of Safari (v17).

Additionally add Jetbrains IDE files to `.gitignore`